### PR TITLE
feat: rebit 

### DIFF
--- a/graphql-gateway/js-graphql/src/resolvers/bit/bit-create.ts
+++ b/graphql-gateway/js-graphql/src/resolvers/bit/bit-create.ts
@@ -3,7 +3,7 @@ import driver from '../../util/neo4j-driver';
 
 dotenv.config();
 
-const bitPostResolver = async (_p: any, { content }: any, { me }: any) => {
+export const postBitResolver = async (_p: any, { content }: any, { me }: any) => {
   const session = driver.session({ database: 'neo4j' });
   try {
     const query = `
@@ -11,14 +11,14 @@ const bitPostResolver = async (_p: any, { content }: any, { me }: any) => {
             WITH u
             MATCH (:Bit)
             WITH u, toString(COUNT(*) + 1) as count
-            CREATE (b:Bit {
+            MERGE (b:Bit {
                    id: count,
                    content: $content,
                    createAt: $createAt,
                    totalLike: $totalLike,
                    likeGivers: []
             })
-            CREATE (u)-[:POST]->(b)
+            MERGE (u)-[:POST]->(b)
             RETURN b
         `;
     const result = await session.run(query, {
@@ -36,4 +36,41 @@ const bitPostResolver = async (_p: any, { content }: any, { me }: any) => {
   }
 };
 
-module.exports = bitPostResolver;
+export const reBitResolver = async (_p: any, { content, id }: any, { me }: any) => {
+  const session = driver.session({ database: 'neo4j' });
+  try {
+    const query = `
+            MATCH (u:User {id: $uid})
+            WITH u
+            MATCH (b1:Bit {id: $bid})
+            WITH u, b1
+            MATCH (:Bit)
+            WITH u, b1, toString(COUNT(*) + 1) as count
+            MERGE (b2:Bit {
+                   id: count,
+                   content: $content,
+                   createAt: $createAt,
+                   totalLike: $totalLike,
+                   likeGivers: []
+            })
+            MERGE (u)-[:POST]->(b2)
+            MERGE (b2)-[:REBITED]->(b1)
+            RETURN b2
+        `;
+    const result = await session.run(query, {
+      uid: me.id,
+      bid: id,
+      content,
+      createAt: new Date().toISOString(),
+      totalLike: 0,
+    });
+    return result.records[0].get('b2').properties;
+  } catch (error) {
+    console.error(error);
+    return null;
+  } finally {
+    await session.close();
+  }
+  
+}
+

--- a/graphql-gateway/js-graphql/src/resolvers/bit/bit-create.ts
+++ b/graphql-gateway/js-graphql/src/resolvers/bit/bit-create.ts
@@ -71,6 +71,4 @@ export const reBitResolver = async (_p: any, { content, id }: any, { me }: any) 
   } finally {
     await session.close();
   }
-  
-}
-
+};

--- a/graphql-gateway/js-graphql/src/resolvers/bit/bit-impl.ts
+++ b/graphql-gateway/js-graphql/src/resolvers/bit/bit-impl.ts
@@ -36,4 +36,3 @@ export const reBitResolver = async ({ id }: any) => {
     await session.close();
   }
 };
-

--- a/graphql-gateway/js-graphql/src/resolvers/bit/bit-impl.ts
+++ b/graphql-gateway/js-graphql/src/resolvers/bit/bit-impl.ts
@@ -3,7 +3,7 @@ import driver from '../../util/neo4j-driver';
 
 dotenv.config();
 
-const bitResolver = async ({ id }: any) => {
+export const authorResolver = async ({ id }: any) => {
   const session = driver.session({ database: 'neo4j' });
   try {
     const query = `
@@ -20,4 +20,20 @@ const bitResolver = async ({ id }: any) => {
   }
 };
 
-module.exports = bitResolver;
+export const reBitResolver = async ({ id }: any) => {
+  const session = driver.session({ database: 'neo4j' });
+  try {
+    const query = `
+            MATCH (:Bit {id: $id})-[:REBITED]->(b:Bit)
+            RETURN b
+        `;
+    const result = await session.run(query, { id });
+    return result.records[0].get('b').properties;
+  } catch (error) {
+    console.error(error);
+    return null;
+  } finally {
+    await session.close();
+  }
+};
+

--- a/graphql-gateway/js-graphql/src/resolvers/bit/index.ts
+++ b/graphql-gateway/js-graphql/src/resolvers/bit/index.ts
@@ -1,5 +1,5 @@
 import { likeBit, isLikedBit } from './bit-like';
-import { postBitResolver, reBitResolver} from './bit-create';
+import { postBitResolver, reBitResolver } from './bit-create';
 import { authorResolver, reBitResolver as reBit } from './bit-impl';
 
 export const Query = {

--- a/graphql-gateway/js-graphql/src/resolvers/bit/index.ts
+++ b/graphql-gateway/js-graphql/src/resolvers/bit/index.ts
@@ -1,4 +1,5 @@
 import { likeBit, isLikedBit } from './bit-like';
+import { postBitResolver, reBitResolver} from './bit-create';
 
 export const Query = {
   findBit: require('./bit-find'),
@@ -11,6 +12,7 @@ export const Bit = {
 };
 
 export const Mutation = {
-  postBit: require('./bit-create'),
+  postBit: postBitResolver,
   likeBit,
+  reBit: reBitResolver,
 };

--- a/graphql-gateway/js-graphql/src/resolvers/bit/index.ts
+++ b/graphql-gateway/js-graphql/src/resolvers/bit/index.ts
@@ -1,5 +1,6 @@
 import { likeBit, isLikedBit } from './bit-like';
 import { postBitResolver, reBitResolver} from './bit-create';
+import { authorResolver, reBitResolver as reBit } from './bit-impl';
 
 export const Query = {
   findBit: require('./bit-find'),
@@ -8,7 +9,8 @@ export const Query = {
 };
 
 export const Bit = {
-  author: require('./bit-impl'),
+  author: authorResolver,
+  reBit,
 };
 
 export const Mutation = {

--- a/graphql-gateway/js-graphql/src/schemas/bit.graphql
+++ b/graphql-gateway/js-graphql/src/schemas/bit.graphql
@@ -7,7 +7,7 @@ type Bit {
   totalLike: Int
   likeGivers: [User!]
   "The Bit being ReBit"
-  rebit: Bit
+  reBit: Bit
   # comment: ???
 }
 

--- a/graphql-gateway/js-graphql/src/schemas/bit.graphql
+++ b/graphql-gateway/js-graphql/src/schemas/bit.graphql
@@ -6,6 +6,8 @@ type Bit {
   createAt: String!
   totalLike: Int
   likeGivers: [User!]
+  "The Bit being ReBit"
+  rebit: Bit
   # comment: ???
 }
 
@@ -18,5 +20,6 @@ type Query {
 
 type Mutation {
     postBit(content: String!): Bit
+    reBit(content: String!, id:ID): Bit
     likeBit(id: ID!): Bit
 }

--- a/graphql-gateway/js-graphql/src/schemas/bit.graphql
+++ b/graphql-gateway/js-graphql/src/schemas/bit.graphql
@@ -20,6 +20,6 @@ type Query {
 
 type Mutation {
     postBit(content: String!): Bit
-    reBit(content: String!, id:ID): Bit
+    reBit(content: String!, id: ID!): Bit
     likeBit(id: ID!): Bit
 }


### PR DESCRIPTION
## What's New
User can now rebit by `rebit` resolver
The bit has field `rebit`, if it is rebit, it will return a `bit` object, otherwise null
Fix bug that create bit twice

## Related Issue
#51 

## What Next

## Checklist before requesting a review
- [x] Self reviewed
- [x] Aligned code style 
- [x] No dependency issue
- [x] No linter error
